### PR TITLE
Applied fixes for frictionless latest build

### DIFF
--- a/01-Core.sh
+++ b/01-Core.sh
@@ -54,12 +54,12 @@ wget -N -A "$whitelist_n" "$slacksrc"/n/*.txz			# 17.2	MB
 
 echo Use the script that downloads slacky packages by name because this is a bit to much to maintain
 
-wget -N $slacksrc/d/python-2.*.txz		# 11500K
-wget -N $slacksrc/d/perl-5.*.txz		# 14500K - should be 5.3M after cleanup
-wget -N $slacksrc/d/libtool-2.*.txz		# 365K
-wget -N $slacksrc/d/python-setuptools-22.*.txz	# 388K
-wget -N $slacksrc/tcl/tcl-8.*.txz		# 1655K
-wget -N $slacksrc/../extra/wicd/wicd-1.*.txz	# 347K
+wget -N $slacksrc/d/python2-2.*.txz		# 12732K
+wget -N $slacksrc/d/perl-5.*.txz		# 15532K - should be 5.3M after cleanup
+wget -N $slacksrc/d/libtool-2.*.txz		# 420K
+wget -N $slacksrc/d/python-setuptools-*.txz	# 676K
+wget -N $slacksrc/tcl/tcl-8.*.txz		# 2856K
+wget -N $slacksrc/../extra/wicd/wicd-*.txz	# 416K
 wget -N http://packages.nimblex.net/nimblex/b43-firmware-5.100.138-fw-1.txz	# 145K
 if [[ $ARCH = "" ]]; then
  wget -N http://packages.nimblex.net/nimblex/sshfs-fuse-2.3-i486-1.tgz		# 55K

--- a/04-Apps.sh
+++ b/04-Apps.sh
@@ -30,11 +30,11 @@ wget -N -A "$whitelist_l" "$slacksrc"/l/*.txz
 
 if [[ $ARCH = "" ]]; then
  wget -N $extrasrc/system/gslapt/0.5.3i/gslapt-0.5.3i-i486-1sl.txz # 125K
- wget -N http://www.slackware.com/~alien/slackbuilds/flashplayer-plugin/pkg/current/flashplayer-plugin-31.0.0.108-i386-1alien.txz # 6.8M
+ wget -N http://www.slackware.com/~alien/slackbuilds/flashplayer-plugin/pkg/current/flashplayer-plugin-32.0.0.293-i386-1alien.txz # 6.8M
 elif [[ $ARCH = "64" ]]; then
  wget -N $extrasrc/current-x86_64/network/transmission/transmission-2.92-x86_64-3_slonly.txz # 1.5M
  wget -N http://packages.nimblex.net/nimblex/gslapt-0.5.4a-x86_64-1.tgz #167K
- wget -N http://www.slackware.com/~alien/slackbuilds/flashplayer-plugin/pkg64/current/flashplayer-plugin-32.0.0.101-x86_64-1alien.txz # 7.1M
+ wget -N http://www.slackware.com/~alien/slackbuilds/flashplayer-plugin/pkg64/current/flashplayer-plugin-32.0.0.293-x86_64-1alien.txz # 7.3M
 fi
 
 wget -N $slacksrc/l/system-config-printer-*.txz

--- a/05-KDE.sh
+++ b/05-KDE.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -e
 
-. .ftp-credentials
-
 SD=`pwd`
 ARCH=""
 if [[ `uname -m` = "x86_64" ]]; then ARCH="64" ; fi

--- a/07-Devel.sh
+++ b/07-Devel.sh
@@ -2,8 +2,6 @@
 #bash +x
 set -e
 
-. .ftp-credentials
-
 SD=`pwd`
 ARCH=""
 if [[ `uname -m` = "x86_64" ]]; then ARCH="64" ; fi

--- a/08-Service.sh
+++ b/08-Service.sh
@@ -5,7 +5,10 @@ START=`date +%s`
 
 cp_new_lzm() {
 
-REMOTE="admin@seif:/share/Bogdan/packages/nimblex/lzm/"
+# Uncomment to enable REMOTE
+#REMOTE="admin@seif:/share/Bogdan/packages/nimblex/lzm/"
+
+if [ ! -d ISO-test${ARCH} ]; then mkdir ISO-test${ARCH}; fi
 
 rsync -av	01-Core${ARCH}.lzm \
 		02-Xorg${ARCH}.lzm \
@@ -15,13 +18,15 @@ rsync -av	01-Core${ARCH}.lzm \
 		10-Virtual${ARCH}.lzm \
 ISO-test${ARCH}/nimblex${ARCH}/
 
-rsync -av	01-Core${ARCH}.lzm \
-		02-Xorg${ARCH}.lzm \
-		04-Apps${ARCH}.lzm \
-		05-KDE${ARCH}.lzm \
-		07-Devel${ARCH}.lzm \
-		10-Virtual${ARCH}.lzm \
-$REMOTE
+if [ ! -z $REMOTE ]; then
+	rsync -av	01-Core${ARCH}.lzm \
+			02-Xorg${ARCH}.lzm \
+			04-Apps${ARCH}.lzm \
+			05-KDE${ARCH}.lzm \
+			07-Devel${ARCH}.lzm \
+			10-Virtual${ARCH}.lzm \
+	$REMOTE
+fi
 
 }
 

--- a/10-Virtual.sh
+++ b/10-Virtual.sh
@@ -2,8 +2,6 @@
 #bash +x
 set -e
 
-. .ftp-credentials
-
 SD=`pwd`
 ARCH=""
 if [[ `uname -m` = "x86_64" ]]; then ARCH="64" ; fi
@@ -29,9 +27,9 @@ if [[ $ARCH = "" ]]; then
 elif [[ $ARCH = "64" ]]; then
  wget -N $nxsrc/acpica-20170531-x86_64-1.txz		# 741K
  wget -N $nxsrc/drbd-utils-8.9.2-x86_64-1.txz		# 182K
- wget -N $slacksrc/l/gobject-introspection-1.58.3-x86_64-1.txz	# 1.1M
- wget -N $slacksrc/l/libedit-20181209_3.1-x86_64-1.txz	# 101K
- wget -N $nxsrc/leveldb-1.9.0-x86_64-1.txz		# 160K
+ wget -N $slacksrc/l/gobject-introspection-1.*-x86_64-1.txz	# 1.2M
+ wget -N $slacksrc/l/libedit-*-x86_64-1.txz	# 104K
+ wget -N $nxsrc/leveldb-1.15.0-x86_64-1.txz		# 151K
  wget -N $nxsrc/libvirt-3.9.0-x86_64-1.txz		# 9.3M
  wget -N $nxsrc/libvirt-glib-1.0.0-x86_64-1.txz		# 300K
  wget -N $nxsrc/libvirt-python-3.9.0-x86_64-1.txz	# 215K


### PR DESCRIPTION
To fix issue #5

**Changes summary:**
- Updated package versions to latest ones and changed their size comments [01-Core.sh, 04-Apps.sh, 10-Virtual.sh]
- Removed unnecessary `. .ftp-credentials` because they are in later if statements [05-KDE.sh, 07-Devel.sh]
- Made `$REMOTE` optional [builds fine without it now, commented by default, uncomment to use it]
- Create a `ISO-test${ARCH}` dir if does not exist [to fix build failure]